### PR TITLE
Fixed incorrect carouselController named param in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ FlutterCarousel(
   autoPlayAnimationDuration: const Duration(milliseconds: 800),
   autoPlayCurve: Curves.fastOutSlowIn,
   enlargeCenterPage: false,
-  controller CarouselController(),
+  controller: CarouselController(),
   onPageChanged: callbackFunction,
   pageSnapping: true,
   scrollDirection: Axis.horizontal,
@@ -180,7 +180,7 @@ class CarouselDemo extends StatelessWidget {
         items: child,
         options: CarouselOptions(
           autoPlay: false,
-          controller buttonCarouselController,
+          controller: buttonCarouselController,
           enlargeCenterPage: true,
           viewportFraction: 0.9,
           aspectRatio: 2.0,

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ FlutterCarousel(
   autoPlayAnimationDuration: const Duration(milliseconds: 800),
   autoPlayCurve: Curves.fastOutSlowIn,
   enlargeCenterPage: false,
-  carouselController: CarouselController(),
+  controller CarouselController(),
   onPageChanged: callbackFunction,
   pageSnapping: true,
   scrollDirection: Axis.horizontal,
@@ -180,7 +180,7 @@ class CarouselDemo extends StatelessWidget {
         items: child,
         options: CarouselOptions(
           autoPlay: false,
-          carouselController: buttonCarouselController,
+          controller buttonCarouselController,
           enlargeCenterPage: true,
           viewportFraction: 0.9,
           aspectRatio: 2.0,


### PR DESCRIPTION
It looks like you made a breaking change a while back where you changed the parameter `carouselController` to `controller`. The readme wasn't updated, causing confusion for new users. This PR updates the documentation appropriately. 