### PR TITLE
Fixed(?) a bunch of documentation comments that appear to be missing a '/'

### DIFF
--- a/lib/src/helpers/flutter_carousel_options.dart
+++ b/lib/src/helpers/flutter_carousel_options.dart
@@ -187,12 +187,12 @@ class CarouselOptions {
   final bool reverse;
 
   ///A ScrollBehavior that will be applied to this widget individually.
-  //
-  // Defaults to null, wherein the inherited ScrollBehavior is copied and modified to alter the viewport decoration, like Scrollbars.
-  //
-  // ScrollBehaviors also provide ScrollPhysics. If an explicit ScrollPhysics is provided in physics, it will take precedence, followed by scrollBehavior, and then the inherited ancestor ScrollBehavior.
-  //
-  // The ScrollBehavior of the inherited ScrollConfiguration will be modified by default to not apply a Scrollbar.
+  ///
+  /// Defaults to null, wherein the inherited ScrollBehavior is copied and modified to alter the viewport decoration, like Scrollbars.
+  ///
+  /// ScrollBehaviors also provide ScrollPhysics. If an explicit ScrollPhysics is provided in physics, it will take precedence, followed by scrollBehavior, and then the inherited ancestor ScrollBehavior.
+  ///
+  /// The ScrollBehavior of the inherited ScrollConfiguration will be modified by default to not apply a Scrollbar.
   final ScrollBehavior? scrollBehavior;
 
   /// The axis along which the page view scrolls.

--- a/lib/src/utils/flutter_carousel_utils.dart
+++ b/lib/src/utils/flutter_carousel_utils.dart
@@ -1,12 +1,12 @@
 /// Converts an index of a set size to the corresponding index of a collection of another size
 /// as if they were circular.
 ///
-/// Takes a [position] from collection Foo, a [base] from where Foo's index originated
-/// and the [length] of a second collection Baa, for which the correlating index is sought.
+/// Takes a [position] from collection `Foo`, a [base] from where `Foo`'s index originated
+/// and the [length] of a second collection `Bar`, for which the correlating index is sought.
 ///
-/// For example; We have a Carousel of 10000(simulating infinity) but only 6 images.
+/// For example; We have a Carousel of 10000 (simulating infinity) but only 6 images.
 /// We need to repeat the images to give the illusion of a never ending stream.
-/// By calling _getRealIndex with position and base we get an offset.
+/// By calling `getRealIndex` with position and base we get an offset.
 /// This offset modulo our length, 6, will return a number between 0 and 5, which represent the image
 /// to be placed in the given position.
 int getRealIndex(int position, int base, int? length) {


### PR DESCRIPTION
Appears that the comment for the scroll physics property in `carousel_options` had some extra comments that weren't triple-slashed, so they would be hidden by intellisense in IDEs like VSCode and Android Studio. 

I doubt this was intentional as no other properties were commented like this, and the information is good to have at-a-glance.

I've also made a couple of changes to the comment above the getRealIndex method which had a typo (Baa -> Bar) and surrounding a few terms with markdown for better reading in intellisense :)