### PR TITLE
Fix/expandable carousel options

### DIFF
--- a/example/lib/app_themes.dart
+++ b/example/lib/app_themes.dart
@@ -18,12 +18,12 @@ class AppThemes {
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: WidgetStateProperty.all(Colors.redAccent),
+        backgroundColor: MaterialStateProperty.all(Colors.redAccent),
       ),
     ),
     textButtonTheme: TextButtonThemeData(
       style: ButtonStyle(
-        foregroundColor: WidgetStateProperty.all(lightColor),
+        foregroundColor: MaterialStateProperty.all(lightColor),
       ),
     ),
     appBarTheme: const AppBarTheme(
@@ -70,12 +70,12 @@ class AppThemes {
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: WidgetStateProperty.all(Colors.redAccent),
+        backgroundColor: MaterialStateProperty.all(Colors.redAccent),
       ),
     ),
     textButtonTheme: TextButtonThemeData(
       style: ButtonStyle(
-        foregroundColor: WidgetStateProperty.all(darkColor),
+        foregroundColor: MaterialStateProperty.all(darkColor),
       ),
     ),
     appBarTheme: const AppBarTheme(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/flutter_carousel_widget.dart';
 
 import 'app_themes.dart';

--- a/lib/src/_expandable_carousel_widget.dart
+++ b/lib/src/_expandable_carousel_widget.dart
@@ -3,7 +3,7 @@ library flutter_carousel_widget;
 import 'dart:async';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/components/overflow_page.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_controller.dart';

--- a/lib/src/_flutter_carousel_widget.dart
+++ b/lib/src/_flutter_carousel_widget.dart
@@ -3,7 +3,7 @@ library flutter_carousel_widget;
 import 'dart:async';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/enums/center_page_enlarge_strategy.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_controller.dart';

--- a/lib/src/components/overflow_page.dart
+++ b/lib/src/components/overflow_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/components/size_reporting_widget.dart';
 
 class OverflowPage extends StatelessWidget {

--- a/lib/src/components/size_reporting_widget.dart
+++ b/lib/src/components/size_reporting_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 
 class SizeReportingWidget extends StatefulWidget {
   const SizeReportingWidget({

--- a/lib/src/helpers/flutter_carousel_controller.dart
+++ b/lib/src/helpers/flutter_carousel_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_state.dart';
 import 'package:flutter_carousel_widget/src/utils/flutter_carousel_utils.dart';

--- a/lib/src/helpers/flutter_carousel_controller.dart
+++ b/lib/src/helpers/flutter_carousel_controller.dart
@@ -3,9 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_state.dart';
+import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_controller.dart';
 import 'package:flutter_carousel_widget/src/utils/flutter_carousel_utils.dart';
 
-abstract class CarouselController {
+abstract class CarouselController extends ExpandableCarouselController{
   factory CarouselController() => CarouselControllerImpl();
 
   bool get ready;

--- a/lib/src/helpers/flutter_carousel_options.dart
+++ b/lib/src/helpers/flutter_carousel_options.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/enums/center_page_enlarge_strategy.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_controller.dart';

--- a/lib/src/helpers/flutter_carousel_options.dart
+++ b/lib/src/helpers/flutter_carousel_options.dart
@@ -3,97 +3,50 @@ import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/enums/center_page_enlarge_strategy.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_controller.dart';
+import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_options.dart';
 import 'package:flutter_carousel_widget/src/indicators/circular_slide_indicator.dart';
 import 'package:flutter_carousel_widget/src/indicators/slide_indicator.dart';
 
-class CarouselOptions {
+class CarouselOptions extends ExpandableCarouselOptions{
   CarouselOptions({
-    this.height,
-    this.aspectRatio,
-    this.viewportFraction = 0.9,
-    this.initialPage = 0,
+    super.height,
+    super.aspectRatio,
+    super.viewportFraction = 0.9,
+    super.initialPage = 0,
     this.enableInfiniteScroll = false,
-    this.reverse = false,
-    this.autoPlay = false,
-    this.autoPlayInterval = const Duration(seconds: 5),
-    this.autoPlayAnimationDuration = const Duration(milliseconds: 300),
-    this.autoPlayCurve = Curves.easeInCubic,
+    super.reverse = false,
+    super.autoPlay = false,
+    super.autoPlayInterval = const Duration(seconds: 5),
+    super.autoPlayAnimationDuration = const Duration(milliseconds: 300),
+    super.autoPlayCurve = Curves.easeInCubic,
     this.enlargeCenterPage = false,
-    this.controller,
-    this.onPageChanged,
-    this.onScrolled,
-    this.physics = const BouncingScrollPhysics(),
-    this.scrollDirection = Axis.horizontal,
-    this.pauseAutoPlayOnTouch = true,
-    this.pauseAutoPlayOnManualNavigate = true,
-    this.pauseAutoPlayInFiniteScroll = false,
-    this.pageViewKey,
-    this.keepPage = true,
+    super.controller,
+    super.onPageChanged,
+    super.onScrolled,
+    super.physics = const BouncingScrollPhysics(),
+    super.scrollDirection = Axis.horizontal,
+    super.pauseAutoPlayOnTouch = true,
+    super.pauseAutoPlayOnManualNavigate = true,
+    super.pauseAutoPlayInFiniteScroll = false,
+    super.pageViewKey,
+    super.keepPage = true,
     this.enlargeStrategy = CenterPageEnlargeStrategy.scale,
     this.disableCenter = false,
-    this.showIndicator = true,
-    this.floatingIndicator = true,
-    this.indicatorMargin = 8.0,
-    this.slideIndicator = const CircularSlideIndicator(),
-    this.clipBehavior = Clip.antiAlias,
-    this.scrollBehavior,
-    this.pageSnapping = true,
-    this.padEnds = true,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.allowImplicitScrolling = false,
-    this.restorationId,
+    super.showIndicator = true,
+    super.floatingIndicator = true,
+    super.indicatorMargin = 8.0,
+    super.slideIndicator = const CircularSlideIndicator(),
+    super.clipBehavior = Clip.antiAlias,
+    super.scrollBehavior,
+    super.pageSnapping = true,
+    super.padEnds = true,
+    super.dragStartBehavior = DragStartBehavior.start,
+    super.allowImplicitScrolling = false,
+    super.restorationId,
   }) : assert(showIndicator == true ? slideIndicator != null : true);
-
-  /// Called whenever the page in the center of the viewport changes.
-  final Function(int index, CarouselPageChangedReason reason)? onPageChanged;
-
-  /// Controls whether the widget's pages will respond to [RenderObject.showOnScreen], which will allow for implicit accessibility scrolling.
-  ///
-  /// Corresponds to Material's PageView's allowImplicitScrolling parameter: https://api.flutter.dev/flutter/widgets/PageView-class.html
-  final bool allowImplicitScrolling;
-
-  /// Aspect ratio is used if no height have been declared.
-  ///
-  /// Defaults to 1:1 (square) aspect ratio.
-  final double? aspectRatio;
-
-  /// Enables auto play, sliding one page at a time.
-  ///
-  /// Use [autoPlayInterval] to determent the frequency of slides.
-  /// Defaults to false.
-  final bool autoPlay;
-
-  /// The animation duration between two transitioning pages while in auto playback.
-  ///
-  /// Defaults to 500 ms.
-  final Duration autoPlayAnimationDuration;
-
-  /// Determines the animation curve physics.
-  ///
-  /// Defaults to [Curves.easeInOut].
-  final Curve autoPlayCurve;
-
-  /// Sets Duration to determent the frequency of slides when
-  ///
-  /// [autoPlay] is set to true.
-  /// Defaults to 5 seconds.
-  final Duration autoPlayInterval;
-
-  /// The content will be clipped (or not) according to this option.
-  ///
-  /// Corresponds to Material's PageView's clipBehavior parameter: https://api.flutter.dev/flutter/widgets/PageView-class.html
-  final Clip clipBehavior;
-
-  /// A [MapController], used to control the map.
-  final CarouselController? controller;
 
   /// Whether or not to disable the `Center` widget for each slide.
   final bool disableCenter;
-
-  /// Determines the way that drag start behavior is handled.
-  ///
-  /// Corresponds to Material's PageView's dragStartBehavior parameter: https://api.flutter.dev/flutter/widgets/PageView-class.html
-  final DragStartBehavior dragStartBehavior;
 
   ///Determines if carousel should loop infinitely or be limited to item length.
   ///
@@ -108,108 +61,6 @@ class CarouselOptions {
 
   /// Use `enlargeStrategy` to determine which method to enlarge the center page.
   final CenterPageEnlargeStrategy enlargeStrategy;
-
-  /// Whether or not to float `SlideIndicator` over `Carousel`.
-  final bool floatingIndicator;
-
-  /// Set carousel height and overrides any existing [aspectRatio].
-  final double? height;
-
-  /// Indicator margin
-  final double? indicatorMargin;
-
-  /// The initial page to show when first creating the [CarouselSlider].
-  ///
-  /// Defaults to 0.
-  final int initialPage;
-
-  /// Whether or not to keep pages in PageView
-  final bool keepPage;
-
-  /// Called whenever the carousel is scrolled
-  final ValueChanged<double?>? onScrolled;
-
-  /// Whether to add padding to both ends of the list.
-  /// If this is set to true and [viewportFraction] < 1.0, padding will be
-  /// added such that the first and last child slivers will be in the center
-  /// of the viewport when scrolled all the way to the start or end,
-  /// respectively.
-  /// If [viewportFraction] >= 1.0, this property has no effect.
-  /// This property defaults to true and must not be null.
-  final bool padEnds;
-
-  /// Set to false to disable page snapping, useful for custom scroll behavior.
-  ///
-  /// Default to `true`.
-  final bool pageSnapping;
-
-  /// Pass a `PageStorageKey` if you want to keep the PageView's position when
-  /// it was recreated.
-  final PageStorageKey<dynamic>? pageViewKey;
-
-  /// If `enableInfiniteScroll` is `false`, and `autoPlay` is `true`, this option
-  /// decide the carousel should go to the first item when it reach the last item or not.
-  /// If set to `true`, the auto play will be paused when it reach the last item.
-  /// If set to `false`, the auto play function will animate to the first item when it was
-  /// in the last item.
-  final bool pauseAutoPlayInFiniteScroll;
-
-  /// If `true`, the auto play function will be paused when user is calling
-  /// pageController's `nextPage` or `previousPage` or `animateToPage` method.
-  /// And after the animation complete, the auto play will be resumed.
-  /// Default to `true`.
-  final bool pauseAutoPlayOnManualNavigate;
-
-  /// If `true`, the auto play function will be paused when user is interacting with
-  /// the carousel, and will be resumed when user finish interacting.
-  /// Default to `true`.
-  final bool pauseAutoPlayOnTouch;
-
-  /// How the carousel should respond to user input.
-  ///
-  /// For example, determines how the items continues to animate after the
-  /// user stops dragging the page view.
-  ///
-  /// The physics are modified to snap to page boundaries using
-  /// [PageScrollPhysics] prior to being used.
-  ///
-  /// Defaults to matching platform conventions.
-  final ScrollPhysics? physics;
-
-  /// Restoration ID to save and restore the scroll offset of the scrollable.
-  ///
-  /// Corresponds to Material's PageView's restorationId parameter: https://api.flutter.dev/flutter/widgets/PageView-class.html
-  final String? restorationId;
-
-  /// Reverse the order of items if set to true.
-  ///
-  /// Defaults to false.
-  final bool reverse;
-
-  ///A ScrollBehavior that will be applied to this widget individually.
-  ///
-  /// Defaults to null, wherein the inherited ScrollBehavior is copied and modified to alter the viewport decoration, like Scrollbars.
-  ///
-  /// ScrollBehaviors also provide ScrollPhysics. If an explicit ScrollPhysics is provided in physics, it will take precedence, followed by scrollBehavior, and then the inherited ancestor ScrollBehavior.
-  ///
-  /// The ScrollBehavior of the inherited ScrollConfiguration will be modified by default to not apply a Scrollbar.
-  final ScrollBehavior? scrollBehavior;
-
-  /// The axis along which the page view scrolls.
-  ///
-  /// Defaults to [Axis.horizontal].
-  final Axis scrollDirection;
-
-  /// Whether or not to show the `SlideIndicator` for each slide.
-  final bool showIndicator;
-
-  /// Use `slideIndicator` to determine which indicator you want to show for each slide.
-  final SlideIndicator? slideIndicator;
-
-  /// The fraction of the viewport that each page should occupy.
-  ///
-  /// Defaults to 0.8, which means each page fills 80% of the carousel.
-  final double viewportFraction;
 
   /// Copy With Constructor
   CarouselOptions copyWith({

--- a/lib/src/helpers/flutter_carousel_state.dart
+++ b/lib/src/helpers/flutter_carousel_state.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_carousel_options.dart';
 

--- a/lib/src/helpers/flutter_expandable_carousel_controller.dart
+++ b/lib/src/helpers/flutter_expandable_carousel_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_state.dart';
 import 'package:flutter_carousel_widget/src/utils/flutter_carousel_utils.dart';

--- a/lib/src/helpers/flutter_expandable_carousel_options.dart
+++ b/lib/src/helpers/flutter_expandable_carousel_options.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
-import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_controller.dart';
-import 'package:flutter_carousel_widget/src/indicators/circular_slide_indicator.dart';
-import 'package:flutter_carousel_widget/src/indicators/slide_indicator.dart';
+import 'package:flutter_carousel_widget/flutter_carousel_widget.dart';
 
 class ExpandableCarouselOptions {
   ExpandableCarouselOptions({
@@ -196,7 +193,7 @@ class ExpandableCarouselOptions {
   final double viewportFraction;
 
   /// Copy With Constructor
-  ExpandableCarouselOptions copyWith({
+  ExpandableCarouselOptions copyWithExpandable({
     double? height,
     double? aspectRatio,
     double? viewportFraction,

--- a/lib/src/helpers/flutter_expandable_carousel_options.dart
+++ b/lib/src/helpers/flutter_expandable_carousel_options.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_controller.dart';
 import 'package:flutter_carousel_widget/src/indicators/circular_slide_indicator.dart';

--- a/lib/src/helpers/flutter_expandable_carousel_state.dart
+++ b/lib/src/helpers/flutter_expandable_carousel_state.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/src/enums/carousel_page_changed_reason.dart';
 import 'package:flutter_carousel_widget/src/helpers/flutter_expandable_carousel_options.dart';
 

--- a/lib/src/indicators/circular_static_indicator.dart
+++ b/lib/src/indicators/circular_static_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 import 'package:flutter_carousel_widget/flutter_carousel_widget.dart';
 
 class CircularStaticIndicator extends SlideIndicator {

--- a/lib/src/indicators/models/slide_indicator_options_model.dart
+++ b/lib/src/indicators/models/slide_indicator_options_model.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 
 /// A class that holds the options for the slide indicators.
 class SlideIndicatorOptions {

--- a/lib/src/indicators/slide_indicator.dart
+++ b/lib/src/indicators/slide_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' hide CarouselController;
+import 'package:flutter/material.dart';
 
 /// Abstraction used as a contract for building a slide indicator widget.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_carousel_widget
 description: A customizable carousel slider widget for Flutter, offering features such as infinite scrolling, auto-scrolling, custom child widgets, custom animations, pre-built indicators, expandable carousel widgets, and auto-sized child support.
 
-version: 2.3.0
+version: 3.0.0
 
 homepage: https://pub.dev/packages/flutter_carousel_widget
 repository: https://github.com/nixrajput/flutter_carousel_widget


### PR DESCRIPTION
The goal of this PR is to make ExpandableCarousel backwards compatible (issue https://github.com/nixrajput/flutter_carousel_widget/issues/51)


I had some issues which pop off during my development (hide CarouselController and WidgetStateProperty), I fixed them for me but if it was not necessary I can remove it.

