### PR TITLE
Fixes last item size when ExpandableCarousel has no padsEnds

### DIFF
--- a/lib/src/_expandable_carousel_widget.dart
+++ b/lib/src/_expandable_carousel_widget.dart
@@ -220,7 +220,7 @@ class _ExpandableCarouselWidgetState extends State<ExpandableCarousel>
 
       // Calculate the actual index in case of infinite scrolling
       var actualIndex = getRealIndex(
-        pageIndex.floor() + _carouselState!.initialPage, // Floor the page index
+        pageIndex.round() + _carouselState!.initialPage, // Round the page index
         _carouselState!.realPage, // Initial real page
         widget.itemCount!, // Total number of items
       );
@@ -232,7 +232,7 @@ class _ExpandableCarouselWidgetState extends State<ExpandableCarousel>
             _firstPageLoaded = true; // Set first page loaded flag
             _previousPage = _currentPage; // Update previous page
             _currentPage = actualIndex; // Update current page
-            _pageDelta = pageIndex - pageIndex.floor(); // Calculate delta
+            _pageDelta = pageIndex - pageIndex.round(); // Calculate delta
           });
         }
       });

--- a/lib/src/_flutter_carousel_widget.dart
+++ b/lib/src/_flutter_carousel_widget.dart
@@ -103,7 +103,7 @@ class _FlutterCarouselState extends State<FlutterCarousel>
 
       // Calculate the actual index in case of infinite scrolling
       var actualIndex = getRealIndex(
-        pageIndex.floor() + _carouselState!.initialPage, // Floor the page index
+        pageIndex.round() + _carouselState!.initialPage, // Round the page index
         _carouselState!.realPage, // Initial real page
         widget.itemCount!, // Total number of items
       );
@@ -113,7 +113,7 @@ class _FlutterCarouselState extends State<FlutterCarousel>
         if (mounted) {
           setState(() {
             _currentPage = actualIndex; // Update current page
-            _pageDelta = pageIndex - pageIndex.floor(); // Calculate delta
+            _pageDelta = pageIndex - pageIndex.round(); // Calculate delta
           });
         }
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_carousel_widget
 description: A customizable Flutter carousel widget with infinite scrolling, auto-scrolling, pre-built indicators, expandable widgets, auto-sized child support, and enlarged center page.
 
-version: 3.1.0
+version: 3.1.1
 
 homepage: https://pub.dev/packages/flutter_carousel_widget
 repository: https://github.com/nixrajput/flutter_carousel_widget


### PR DESCRIPTION
# Pull Request Checklist

## What does this PR do?

Fixes bugs or issues https://github.com/nixrajput/flutter_carousel_widget/issues/48

When last item of ExpandableCarousel is bigger than others and `padsEnds` is false, its bottom is clipped. 

That's because 2 carousel items are displayed in the same page, and real page index is floored. So when I switch to slide 4, `pageIndex` is 3.75 (or 3.xxx, depending on viewportFraction, padding etc etc).  And (3.75).floor() is 3, so if the 3rd item is smaller than the 4th, the 4th is displayed but its size is not large enough.

I hope this is clear. You can reproduce with this options in your ExpandableCarousel example : 
```
ExpandableCarouselOptions(
  // viewportFraction: 1.0,
 // enableInfiniteScroll: true, // Remove enabledInfiniteScroll because it makes slide 1 and 4 appear on the same page, so slide 4 sticks to the left of the page and realIndex is correct 
  // enlargeCenterPage: true,
  // initialPage: 1,
  autoPlay: true,
  controller: _controller,
  //showIndicator: false,
  floatingIndicator: false,
  padEnds: false, // Add padEnds
  restorationId: 'expandable_carousel',
)
```

## **Checklist**

### Code Changes
- [ ] I have added new features to the package (e.g., autoplay, indicator customization, etc.)
- [x] I have fixed existing issues (e.g., performance, edge cases)
- [ ] I have improved the overall structure or optimized the codebase

### Documentation
- [ ] I have updated the README file or relevant documentation with the changes
- [ ] I have added code usage examples or updated existing examples to reflect changes
- [ ] I have updated the package version in the `pubspec.yaml` file

### Testing

**General Tests**
- [x] The carousel widget works correctly with default settings
- [x] The carousel can handle a dynamic number of children (images, texts, etc.)
- [x] The carousel supports custom widgets for carousel items

**Autoplay Feature**
- [x] Autoplay starts when enabled and stops when disabled
- [x] Autoplay pauses when the user interacts (swipes/taps) with the carousel
- [x] Autoplay resumes after interaction

**Indicators and Customization**
- [x] The carousel displays indicators correctly and updates when navigating through slides
- [x] Custom indicators (colors, shapes, positions) are rendered correctly
- [x] Custom animations or transitions between slides work as expected

**Looping and Scrolling**
- [x] Infinite loop mode works smoothly without any jumps or glitches
- [x] The carousel scrolls smoothly horizontally and/or vertically
- [x] Pagination and snapping behavior works as expected

**Accessibility**
- [x] The carousel widget supports screen readers (e.g., `Semantics` labels added)
- [x] Users can navigate between items using a keyboard (if necessary)

**Responsiveness**
- [x] The carousel adapts to different screen sizes (mobile, tablet, desktop)
- [x] The carousel responds correctly to device orientation changes

**Error Handling**
- [x] The carousel handles empty/null items gracefully
- [x] The carousel handles large data sets without crashes or performance drops

### Performance
- [ ] I ran performance tests to ensure no regressions
- [x] The carousel renders efficiently, even with a large number of items

### How did you verify your code works?

- I ran manual tests to check various carousel configurations (autoplay, infinite loop, custom widgets)
- All tests pass locally (`flutter test`)